### PR TITLE
feat(di): support for global module #60

### DIFF
--- a/packages/di/src/container/funcs/resolve.func.ts
+++ b/packages/di/src/container/funcs/resolve.func.ts
@@ -1,5 +1,10 @@
 import { Container, Token, ResolveOptions } from '../../';
-import { Errors, ResolveTrace, Provider } from '../../internal';
+import {
+  Errors,
+  ResolveTrace,
+  Provider,
+  getGlobalModule,
+} from '../../internal';
 import { Tracer } from '../../tracer';
 import { DiCycle } from '../../consts/cycle.const';
 
@@ -12,11 +17,9 @@ export async function resolve<T>(
     return this._resolvedValues.get(token);
   }
 
-  if (!options.tracer) {
-    options.tracer = new Tracer<ResolveTrace>();
-  }
+  if (!options.tracer) options.tracer = new Tracer<ResolveTrace>();
 
-  const { extModule, parentModule, tracer, global } = options;
+  const { extModule, parentModule, tracer } = options;
   const traceIdx = tracer.log({ module: this.moduleClass, token });
 
   // B1: extModule has highest priority, so check it first.
@@ -33,8 +36,9 @@ export async function resolve<T>(
     return await parentModule.resolve<T>(token, options);
 
   // B4: provider for this token exists in global module.
-  if (global?.has(token)) {
-    return global.resolve(token, { tracer });
+  const globalModule = getGlobalModule();
+  if (globalModule.has(token)) {
+    return globalModule.resolve(token, { tracer });
   }
 
   // B5:

--- a/packages/di/src/global-module.ts
+++ b/packages/di/src/global-module.ts
@@ -1,0 +1,36 @@
+import {
+  Container,
+  ExportableCnf,
+  GenericProvider,
+  ImportableCnf,
+  moduleMap,
+} from './internal';
+
+class GlobalModule {}
+
+/**
+ * @since 0.11.0
+ */
+export function getGlobalModule() {
+  if (!moduleMap.has(GlobalModule)) {
+    moduleMap.set(GlobalModule, new Container(GlobalModule));
+  }
+
+  return moduleMap.get(GlobalModule);
+}
+
+/**
+ * @since 0.11.0
+ */
+export async function setGlobalModules(
+  modules: (ImportableCnf | ExportableCnf)[],
+) {
+  await getGlobalModule().addModules(modules);
+}
+
+/**
+ * @since 0.11.0
+ */
+export async function setGlobalProviders(providers: GenericProvider[]) {
+  await getGlobalModule().addProviders(providers);
+}

--- a/packages/di/src/index.ts
+++ b/packages/di/src/index.ts
@@ -6,6 +6,7 @@ export { DiError, DiErrorCode } from './consts/error.const';
 export { forwardRef } from './forward-ref';
 export { getModuleMeta, getInjectable } from './utils';
 export { ModuleRef } from './tokens';
+export { setGlobalProviders, setGlobalModules } from './global-module';
 export {
   ModuleMeta,
   ExtModuleMeta,

--- a/packages/di/src/internal.ts
+++ b/packages/di/src/internal.ts
@@ -8,3 +8,4 @@ export * from './utils';
 export * from './types';
 export * from './module-map';
 export * from './provider';
+export * from './global-module';

--- a/packages/di/src/module-map.ts
+++ b/packages/di/src/module-map.ts
@@ -36,16 +36,8 @@ export const moduleMap = new Map<ClassType, Container>();
 /**
  * _**IMPORTANT**: this function can make @cellularjs/di work incorrectly,
  * it should be used for development only(like unit testing)._
- *
- * @deprecated This function is not deprecated, it is just to denote
- * that you should not use this function in production.
  * @since 0.9.0
  */
 export function clearModuleMap() {
-  console.log(
-    '"clearModuleMap" is invoked, this function can make @cellularjs/di work incorrectly, ' +
-      'it should be used for development only(like unit testing).',
-  );
-
   moduleMap.clear();
 }

--- a/packages/di/src/types/provider.type.ts
+++ b/packages/di/src/types/provider.type.ts
@@ -109,19 +109,4 @@ export interface ResolveOptions {
   parentModule?: Container;
 
   tracer?: Tracer;
-
-  /**
-   * Global container.
-   *
-   * If there is no provider matching with the given token,
-   * it will find provider from this global container.
-   *
-   * _Note:_ global container has lower priority than normal container.
-   * ```
-   * extModule > nornal container > global
-   * ```
-   *
-   * @deprecated It will be removed in the near future.
-   */
-  global?: Container;
 }

--- a/packages/di/test/spec/global-module.spec.ts
+++ b/packages/di/test/spec/global-module.spec.ts
@@ -1,0 +1,118 @@
+import 'mocha';
+import { expect } from 'chai';
+import {
+  Container,
+  Injectable,
+  Inject,
+  Module,
+  ExtModuleMeta,
+  clearModuleMap,
+  setGlobalProviders,
+  setGlobalModules,
+  DiErrorCode,
+} from '../../src';
+
+describe('Global module/provider specification:', () => {
+  beforeEach(clearModuleMap);
+
+  it('can setting global providers with setGlobalProviders', async () => {
+    @Injectable()
+    class Tree {
+      constructor(@Inject('name') public name) {}
+    }
+
+    const container = new Container();
+    await container.addProvider(Tree);
+
+    // Case 1: before setting global provider => invalid.
+    try {
+      await container.resolve<Tree>(Tree);
+      expect(true).to.be.false;
+    } catch (err) {
+      expect(err.code).to.eql(DiErrorCode.NoProviderForToken);
+    }
+
+    // Case 2: after setting global provider => valid.
+    await setGlobalProviders([{ token: 'name', useValue: 'Banyan' }]);
+
+    const tree = await container.resolve<Tree>(Tree);
+    expect(tree.name).to.equal('Banyan');
+  });
+
+  it('global provider has lower priority than normal providers', async () => {
+    class Tree {
+      constructor(@Inject('name') public name) {}
+    }
+
+    await setGlobalProviders([{ token: 'name', useValue: 'Orchid' }]);
+
+    // Case 1:
+    const container1 = new Container();
+    await container1.addProviders([
+      { token: Tree, useClass: Tree },
+      { token: 'name', useValue: 'Sunflower' },
+    ]);
+
+    const tree1 = await container1.resolve<Tree>(Tree);
+    expect(tree1.name).to.equal('Sunflower');
+
+    // Case 2:
+    const container2 = new Container();
+    await container2.addProvider(Tree);
+
+    const tree2 = await container2.resolve<Tree>(Tree);
+    expect(tree2.name).to.equal('Orchid');
+  });
+
+  it('global provider has lower priority than ref module(~ extend module)', async () => {
+    class Tree {
+      constructor(@Inject('name') public name) {}
+    }
+
+    await setGlobalProviders([{ token: 'name', useValue: 'Rosewood' }]);
+
+    @Module({ exports: [Tree] })
+    class Forest {
+      static extend(): ExtModuleMeta {
+        return {
+          extModule: Forest,
+          providers: [{ token: 'name', useValue: 'Oak' }],
+        };
+      }
+    }
+
+    // Case 1:
+    const container1 = new Container();
+    await container1.addModule(Forest.extend());
+
+    const tree1 = await container1.resolve<Tree>(Tree);
+    expect(tree1.name).to.equal('Oak');
+
+    // Case 2: if there is no matched extModule provider,
+    // it will try to get global provider.
+    const container2 = new Container();
+    await container2.addModule(Forest);
+
+    const tree2 = await container2.resolve<Tree>(Tree);
+    expect(tree2.name).to.equal('Rosewood');
+  });
+
+  it('can add a module into global module and use it with setGlobalModules', async () => {
+    class Tree {
+      constructor(@Inject('name') public name) {}
+    }
+
+    @Module({
+      providers: [{ token: 'name', useValue: 'Pine' }],
+      exports: [Tree],
+    })
+    class Forest {}
+
+    await setGlobalModules([Forest]);
+
+    const container = new Container();
+    const tree = await container.resolve<Tree>(Tree);
+
+    expect(tree.name).to.equal('Pine');
+  });
+});

--- a/packages/di/test/spec/resolve/resolve.spec.ts
+++ b/packages/di/test/spec/resolve/resolve.spec.ts
@@ -1,13 +1,6 @@
 import 'mocha';
 import { expect } from 'chai';
-import {
-  Container,
-  DiErrorCode,
-  Injectable,
-  Inject,
-  Module,
-  ExtModuleMeta,
-} from '../../../src';
+import { Container, DiErrorCode } from '../../../src';
 
 let container: Container;
 
@@ -24,65 +17,6 @@ describe('Container - resolve:', () => {
     } catch (err) {
       expect(err.code).to.equal(DiErrorCode.NoProviderForToken);
     }
-  });
-
-  it('can resolve global providers', async () => {
-    const global = new Container();
-    await global.addProviders([{ token: 'foo', useValue: 'global' }]);
-
-    @Injectable()
-    class FooBar {
-      constructor(@Inject('foo') public foo) {}
-    }
-
-    await container.addProvider({ token: FooBar, useClass: FooBar });
-
-    const foobar = await container.resolve<FooBar>(FooBar, { global });
-    expect(foobar.foo).to.equal('global');
-  });
-
-  it('global provider has lower priority than normal providers', async () => {
-    const global = new Container();
-    await global.addProviders([{ token: 'foo', useValue: 'global' }]);
-
-    @Injectable()
-    class FooBar {
-      constructor(@Inject('foo') public foo) {}
-    }
-
-    await container.addProviders([
-      { token: FooBar, useClass: FooBar },
-      { token: 'foo', useValue: 'foo' },
-    ]);
-
-    const foobar = await container.resolve<FooBar>(FooBar, { global });
-    expect(foobar.foo).to.equal('foo');
-  });
-
-  it('global provider has lower priority than ref module(~ extend module)', async () => {
-    const global = new Container();
-    await global.addProviders([{ token: 'foo', useValue: 'global' }]);
-
-    @Injectable()
-    class FooBar {
-      constructor(@Inject('foo') public foo) {}
-    }
-
-    @Module({})
-    class FooModule {
-      static extend(): ExtModuleMeta {
-        return {
-          extModule: FooModule,
-          providers: [{ token: 'foo', useValue: 'foo' }],
-          exports: [FooBar],
-        };
-      }
-    }
-
-    await container.addModule(FooModule.extend());
-
-    const foobar = await container.resolve<FooBar>(FooBar, { global });
-    expect(foobar.foo).to.equal('foo');
   });
 
   it('create only one value for provider has cycle is permanent when resolving value in sync', async () => {


### PR DESCRIPTION
## Checklist
- [x] Your commit follow commit convention?
- [x] You added test for bug fixes or new features?
- [x] All tests passed?
- [x] You have rebased with `master` branch?
<!-- - [ ] Relevant docs have been updated? -->

## Does this pull request introduce any breaking change?
- [x] Yes
- [ ] No

This PR will remove deprecated `global` option from `resolve` method of `Container`. Client code can use `setGlobalProviders` or `setGlobalModules` instead.
<!-- If yes, please tell us how it affect the current behavior. -->

## Other note
