### PR TITLE
fix(di): use symbol to hide tracer param instead of warning

### DIFF
--- a/packages/di/src/types/provider.type.ts
+++ b/packages/di/src/types/provider.type.ts
@@ -92,6 +92,12 @@ export interface ClassifiedUseFuncDep {
   shouldResolve: boolean;
 }
 
+/**
+ * _DO NOT TRY TO IMPORT THIS KEY, IT IS **NOT** PUBLIC FOR EXTERNAL USE._
+ * @since 0.15.1
+ */
+export const _TRACER_KEY = Symbol('tracer');
+
 export interface ResolveOptions {
   /**
    * `extModule` is a container object that is a "child" of this container.
@@ -117,5 +123,5 @@ export interface ResolveOptions {
    *
    * @since 0.11.0
    */
-  tracer?: Tracer;
+  [_TRACER_KEY]?: Tracer;
 }


### PR DESCRIPTION
## Checklist
- [x] Your commit follow commit convention?
- [ ] You added test for bug fixes or new features?
- [x] All tests passed?
- [x] You have rebased with `master` branch?
<!-- - [ ] Relevant docs have been updated? -->

## Does this pull request introduce any breaking change?
- [x] Yes
- [ ] No

Technically, yes! At the previous version, I only warn people for not using tracer params. Now, I use a symbol to hide tracer param from external world.
<!-- If yes, please tell us how it affect the current behavior. -->

## Other note
