### PR TITLE
fix(di): use symbol to hide parentModule from external world

### DIFF
--- a/packages/di/src/container/funcs/resolve.func.ts
+++ b/packages/di/src/container/funcs/resolve.func.ts
@@ -5,6 +5,7 @@ import {
   Provider,
   getGlobalModule,
   _TRACER_KEY,
+  _PARENT_MODULE_KEY,
 } from '../../internal';
 import { Tracer } from '../../tracer';
 import { DiCycle } from '../../consts/cycle.const';
@@ -20,14 +21,15 @@ export async function resolve<T = any>(
 
   if (!options[_TRACER_KEY]) options[_TRACER_KEY] = new Tracer<ResolveTrace>();
 
-  const { extModule, parentModule } = options;
+  const { extModule } = options;
+  const parentModule = options[_PARENT_MODULE_KEY];
   const tracer = options[_TRACER_KEY];
   const traceIdx = tracer.log({ module: this.moduleClass, token });
 
   // B1: extModule has highest priority, so check it first.
   if (extModule?.has(token))
     return await extModule.resolve<T>(token, {
-      parentModule: this,
+      [_PARENT_MODULE_KEY]: this,
       [_TRACER_KEY]: tracer,
     });
 

--- a/packages/di/src/types/provider.type.ts
+++ b/packages/di/src/types/provider.type.ts
@@ -98,6 +98,12 @@ export interface ClassifiedUseFuncDep {
  */
 export const _TRACER_KEY = Symbol('tracer');
 
+/**
+ * _DO NOT TRY TO IMPORT THIS KEY, IT IS **NOT** PUBLIC FOR EXTERNAL USE._
+ * @since 0.15.3
+ */
+export const _PARENT_MODULE_KEY = Symbol('parent_module');
+
 export interface ResolveOptions {
   /**
    * `extModule` is a container object that is a "child" of this container.
@@ -114,7 +120,7 @@ export interface ResolveOptions {
   /**
    * @since 0.11.0
    */
-  parentModule?: Container;
+  [_PARENT_MODULE_KEY]?: Container;
 
   /**
    * For now, `Tracer` is not public(via index) and API may be changed.


### PR DESCRIPTION
## Checklist
- [x] Your commit follow commit convention?
- [x] All tests passed?
- [x] You have rebased with `master` branch?
<!-- - [ ] Relevant docs have been updated? -->

## Does this pull request introduce any breaking change?
- [x] Yes
- [ ] No
 
At the previous version, `parentModule` inside [`ResolveOptions`](https://cellularjs.com/docs/foundation/dependency-injection/api#34-resolveoptions)  is for internal usage only but there is no warning about it. This is bad, it cause leake API. 

=> This PR will use Symbol to hide `parentModule` from external world.
## Other note
