### PR TITLE
feat(typeorm): setDefaultCatch, callback function is required

### DIFF
--- a/packages/typeorm/src/tx-catch.ts
+++ b/packages/typeorm/src/tx-catch.ts
@@ -18,7 +18,34 @@ export type TransactionalCatch = (opts: CatchOpts) => Promise<any>;
 
 let _defaultCatch: TransactionalCatch;
 
-export const setDefaultCatch = function (defaultCatch?: TransactionalCatch) {
+/**
+ * Set default error handler when using `Transactional` decorator.
+ *
+ * Example:
+ * ```ts
+ * // global.ts
+ * import { TransactionalCatch, setDefaultCatch } from '@cellularjs/typeorm';
+ *
+ * const MAX_RETRY = 1;
+ *
+ * const txCatch: TransactionalCatch = async ({ error, service, ctx }) => {
+ *  // Ref: https://www.postgresql.org/docs/current/mvcc-serialization-failure-handling.html
+ *  if (error?.code !== '40001') throw error;
+ *
+ *  ctx.try ||= 0;
+ *  ctx.try++;
+ *
+ *  if (ctx.try > MAX_RETRY) throw error;
+ *
+ *  return await service.handle();
+ * }
+ *
+ * setDefaultCatch(txCatch);
+ * ```
+ * @since 0.19.0
+ * @see https://cellularjs.com/docs/how-to%20wiki/typeorm#42-error-handling
+ */
+export const setDefaultCatch = function (defaultCatch: TransactionalCatch) {
   if (_defaultCatch) {
     throw new Error('Default catch already exist!');
   }
@@ -27,14 +54,14 @@ export const setDefaultCatch = function (defaultCatch?: TransactionalCatch) {
 };
 
 /**
- * For internal only!
+ * For internal usage only!
  */
 export const clearDefaultCatch = function () {
   _defaultCatch = null;
 };
 
 /**
- * For internal only!
+ * For internal usage only!
  */
 export const getDefaultCatch = function () {
   return _defaultCatch;


### PR DESCRIPTION
## Checklist
- [x] Your commit follow commit convention?
- [x] You added test for bug fixes or new features?
- [x] All tests passed?
- [x] You have rebased with `master` branch?
<!-- - [ ] Relevant docs have been updated? -->

## Does this pull request introduce any breaking change?
- [x] Yes
- [ ] No

In the previous version, invoking `setDefaultCatch()` without callback is valid.
```ts
// Before:
setDefaultCatch(); // ok

// After:
setDefaultCatch();// error
```
<!-- If yes, please tell us how it affect the current behavior. -->

## Other note
